### PR TITLE
travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,14 @@ language: php
 sudo: false
 php:
   - 7.0
-script:
+install:
   - which pear
   - find ~ -name pear -print
   - pear list
   - pear uninstall xml_util structures_graph archive_tar console_getopt pear
   - which pear
   - ./run-installer.sh
+script:
   - find ~ -name pear -print
   - /home/travis/pear/bin/pear list
   - php go-pear.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
 language: php
-sudo: true
+sudo: false
 php:
+  - 5.4
+  - 5.5
+  - 5.6
   - 7.0
+  - 7.1
 install:
-  - which pear
-  - find ~ -name pear -print
-  - pear list
-  - pear uninstall xml_util structures_graph archive_tar console_getopt pear
-  - which pear
-  - ./run-installer.sh
 script:
-  - find ~ -name pear -print
-  - /home/travis/pear/bin/pear list
-  - php go-pear.phar
+  - php -l go-pear.phar
+  - php -l install-pear-nozlib.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: php
+sudo: false
+php:
+  - 7.0
+script:
+  - which pear
+  - find ~ -name pear -print
+  - pear list
+  - pear uninstall xml_util structures_graph archive_tar console_getopt pear
+  - which pear
+  - ./run-installer.sh
+  - find ~ -name pear -print
+  - pear list
+  - php go-pear.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ script:
   - which pear
   - ./run-installer.sh
   - find ~ -name pear -print
-  - pear list
+  - /home/travis/pear/bin/pear list
   - php go-pear.phar

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-sudo: false
+sudo: true
 php:
   - 7.0
 install:

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,9 @@
 pearweb .phar files
 *******************
 
+.. image:: https://travis-ci.org/pear/pearweb_phars.svg?branch=master
+    :target: https://travis-ci.org/pear/pearweb_phars
+
 Partial source code for the PEAR website:
 
 - ``go-pear.phar``

--- a/run-installer.sh
+++ b/run-installer.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-yes '' | head -10 | ( php go-pear.phar >/dev/null & ) 

--- a/run-installer.sh
+++ b/run-installer.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+yes '' | head -10 | ( php go-pear.phar >/dev/null & ) 


### PR DESCRIPTION
This `run-installer.sh` script works for me on Ubuntu Trusty using PHP 5.5 and 5.6.  It successfully runs the `go-pear.phar` installation without requiring user input.

What I cannot figure out is why Travis appears to run it cleanly, but then doesn't have the PEAR installation available.

Right now, the invocation of the `run-installer.sh` should be doing the install.  The later `php go-pear.phar` is solely to show you the paths it defaults to, which is presumably where the first invocation should have installed it.  Note the build will get stuck here, waiting for user input, so it must be manually canceled or else wait until Travis time-limits the build and kills it.

@kenguest , @till , @cweiske , could you guys try out the `run-installer.sh` script locally to confirm it works in your environments?

More importantly, who could shed some light on why Travis is behaving like it does?  I don't understand why the PEAR installation doesn't properly appear in `/home/travis/pear`, based on the default pathing shown.